### PR TITLE
Fallback to the billing address' first/last name

### DIFF
--- a/src/Action/Integrations/Direct/ExecutePaymentAction.php
+++ b/src/Action/Integrations/Direct/ExecutePaymentAction.php
@@ -81,8 +81,8 @@ final class ExecutePaymentAction extends DirectApiAwareAction implements ActionI
             "currency" => $this->api->getOption('currency'),
             "description" => $description,
             "apply3DSecure" => "UseMSPSetting",
-            "customerFirstName" => $order->getCustomer()->getFirstname(),
-            "customerLastName" => $order->getCustomer()->getLastname(),
+            "customerFirstName" => ( (!empty($order->getCustomer()->getFirstname())) ? $order->getCustomer()->getFirstname() : $billingAddress->getFirstName() ),
+            "customerLastName" => ( (!empty($order->getCustomer()->getLastname())) ? $order->getCustomer()->getLastname() : $billingAddress->getLastName() ),
             "billingAddress" => [
                 "address1" => $billingStreet,
                 "city" => $billingAddress->getCity(),


### PR DESCRIPTION
SagePay does not accept payment in case of submitting data with null customerFirstName and customerLastName fields what happens for non-registered Sylius customers. I've added fallback to BillingAddress names for these situations.