### PR TITLE
Mark request as failed on card identification

### DIFF
--- a/src/Action/Integrations/Direct/StatusAction.php
+++ b/src/Action/Integrations/Direct/StatusAction.php
@@ -92,7 +92,13 @@ class StatusAction extends DirectApiAwareAction implements ActionInterface, ApiA
             $executePaymentRequest = new ExecutePayment($payment);
             $executePaymentRequest->setModel($model);
             $this->gateway->execute($executePaymentRequest);
-            $request->markNew();
+            
+            $response = json_decode($model["payment_response"]);
+            if (isset($response->errors)) {
+                $request->markFailed();
+            } else {
+                $request->markNew();
+            }
         } else {
             $request->markNew();
         }


### PR DESCRIPTION
If card identification doesn't go through, mark the request as failed.