### PR TITLE
Fix for Typo on Encryptation

### DIFF
--- a/src/Resources/translations/messages.en.yml
+++ b/src/Resources/translations/messages.en.yml
@@ -5,8 +5,8 @@ sbarbat_sylius_sagepay_plugin:
         live: Live
         vendor_name: Vendor name
         currency: Currency code for payments
-        encryptation_password_test: Encryptation password for sandbox mode
-        encryptation_password_live: Encryptation password for live mode
+        encryptation_password_test: Encryption password for sandbox mode
+        encryptation_password_live: Encryption password for live mode
         sagepay_form_gateway_label: Sagepay form gateway
         sagepay_server_gateway_label: Sagepay server iframe gateway
         sagepay_direct_gateway_label: Sagepay direct gateway


### PR DESCRIPTION
In the admin area it shows 'Encryptation'.  Should be 'Encryption'